### PR TITLE
Ensure DB tables exist on startup

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -6,6 +6,9 @@ from . import schemas, hashing, models, tokens
 
 app = FastAPI()
 
+# Ensure all database tables are created on startup
+Base.metadata.create_all(bind=engine)
+
 @app.get("/")
 def home():
     return "working"


### PR DESCRIPTION
## Summary
- trigger SQLAlchemy to create all tables when the API starts

## Testing
- `python3 -m py_compile BackEnd/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6862d99818d4832693a3da7f6a755957