### PR TITLE
Fix API integration and React hooks

### DIFF
--- a/BackEnd/auth/dependencies.py
+++ b/BackEnd/auth/dependencies.py
@@ -6,7 +6,10 @@ from sqlalchemy.orm import Session
 from .. import models, database
 from .tokens import verify_access_token
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+# OAuth2PasswordBearer expects the full login URL relative to the API root.
+# Our login route lives under the /user prefix, so we specify that here to
+# ensure FastAPI generates the correct OpenAPI docs and token retrieval works.
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/user/login")
 
 def get_db():
     db = database.SessionLocal()

--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -14,8 +14,9 @@ app = FastAPI(
 )
 
 # Enable CORS (adjust origins for frontend later)
+# Allow requests from the development frontend served by Vite
 origins = [
-    "http://localhost:3000",  # React frontend default
+    "http://localhost:8080",
 ]
 
 app.add_middleware(

--- a/FrontEnd/src/pages/Dashboard.tsx
+++ b/FrontEnd/src/pages/Dashboard.tsx
@@ -31,14 +31,14 @@ import JobMatchesList from '@/components/dashboard/JobMatchesList';
 import ApplicationsList from '@/components/dashboard/ApplicationsList';
 import AnalyticsDashboard from '@/components/dashboard/AnalyticsDashboard';
 
-const { data: profile } = useQuery({
-  queryKey: ["profile"],
-  queryFn: fetchProfile,
-});
-
 const Dashboard = () => {
   const [activeTab, setActiveTab] = React.useState("matches");
   const [isEditingProfile, setIsEditingProfile] = React.useState(false);
+  // Fetch the current user's profile once the dashboard is rendered
+  const { data: profile } = useQuery({
+    queryKey: ["profile"],
+    queryFn: fetchProfile,
+  });
   
   return (
     <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
## Summary
- fix OAuth token URL to point to `/user/login`
- update allowed CORS origin to match Vite dev server
- move `useQuery` call inside Dashboard component

## Testing
- `npm run lint` *(fails: cannot read properties of undefined)*
- `npm run build`
- `pip install -r requirements.txt`
- `python -m uvicorn main:app --reload --port 8000` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_687ce4500314832688bfe4f062c004e0