### PR TITLE
Update dashboard auth and cleanup

### DIFF
--- a/FrontEnd/src/components/Navbar.tsx
+++ b/FrontEnd/src/components/Navbar.tsx
@@ -3,11 +3,13 @@ import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Sun, Moon, Menu, X } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
 
 const Navbar = () => {
-	const [isDarkMode, setIsDarkMode] = useState(false);
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
-	const location = useLocation();
+        const [isDarkMode, setIsDarkMode] = useState(false);
+        const [isMenuOpen, setIsMenuOpen] = useState(false);
+        const location = useLocation();
+        const { token, logout } = useAuth();
 
 	useEffect(() => {
 		const isDark = localStorage.getItem("theme") === "dark";
@@ -85,28 +87,35 @@ const Navbar = () => {
 							>
 								FAQ
 							</Link>
-							<Link
-								to="/dashboard"
-								className={`text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 ${location.pathname === "/dashboard"
-										? "text-blue-600 dark:text-blue-400"
-										: ""
-									}`}
-							>
-								Dashboard
-							</Link>
-							<Link to="/signin">
-								<Button variant="outline" className="mr-2">
-									Sign In
-								</Button>
-							</Link>
-							<Link to="/signup">
-								<Button>Sign Up</Button>
-							</Link>
-							<button
-								onClick={toggleDarkMode}
-								className="p-2 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200"
-								aria-label="Toggle dark mode"
-							>
+                                                        {token ? (
+                                                                <>
+                                                                        <Link
+                                                                                to="/dashboard"
+                                                                                className={`text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 ${location.pathname === "/dashboard" ? "text-blue-600 dark:text-blue-400" : ""}`}
+                                                                        >
+                                                                                Dashboard
+                                                                        </Link>
+                                                                        <Button variant="outline" onClick={logout} className="mr-2">
+                                                                                Sign Out
+                                                                        </Button>
+                                                                </>
+                                                        ) : (
+                                                                <>
+                                                                        <Link to="/signin">
+                                                                                <Button variant="outline" className="mr-2">
+                                                                                        Sign In
+                                                                                </Button>
+                                                                        </Link>
+                                                                        <Link to="/signup">
+                                                                                <Button>Sign Up</Button>
+                                                                        </Link>
+                                                                </>
+                                                        )}
+                                                        <button
+                                                                onClick={toggleDarkMode}
+                                                                className="p-2 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200"
+                                                                aria-label="Toggle dark mode"
+                                                        >
 								{isDarkMode ? <Sun size={18} /> : <Moon size={18} />}
 							</button>
 						</div>
@@ -143,30 +152,43 @@ const Navbar = () => {
 						>
 							About
 						</Link>
-						<Link
-							to="/dashboard"
-							className={`block px-3 py-2 rounded-md text-base font-medium ${location.pathname === "/dashboard"
-									? "text-blue-600 dark:text-blue-400 bg-gray-100 dark:bg-gray-800"
-									: "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
-								}`}
-							onClick={toggleMenu}
-						>
-							Dashboard
-						</Link>
-						<Link
-							to="/signin"
-							className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
-							onClick={toggleMenu}
-						>
-							Sign In
-						</Link>
-						<Link
-							to="/signup"
-							className="block px-3 py-2 rounded-md text-base font-medium bg-blue-600 text-white hover:bg-blue-700"
-							onClick={toggleMenu}
-						>
-							Sign Up
-						</Link>
+                                                {token ? (
+                                                        <>
+                                                                <Link
+                                                                        to="/dashboard"
+                                                                        className={`block px-3 py-2 rounded-md text-base font-medium ${location.pathname === "/dashboard" ? "text-blue-600 dark:text-blue-400 bg-gray-100 dark:bg-gray-800" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"}`}
+                                                                        onClick={toggleMenu}
+                                                                >
+                                                                        Dashboard
+                                                                </Link>
+                                                                <button
+                                                                        onClick={() => {
+                                                                                logout();
+                                                                                toggleMenu();
+                                                                        }}
+                                                                        className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                                                >
+                                                                        Sign Out
+                                                                </button>
+                                                        </>
+                                                ) : (
+                                                        <>
+                                                                <Link
+                                                                        to="/signin"
+                                                                        className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                                                        onClick={toggleMenu}
+                                                                >
+                                                                        Sign In
+                                                                </Link>
+                                                                <Link
+                                                                        to="/signup"
+                                                                        className="block px-3 py-2 rounded-md text-base font-medium bg-blue-600 text-white hover:bg-blue-700"
+                                                                        onClick={toggleMenu}
+                                                                >
+                                                                        Sign Up
+                                                                </Link>
+                                                        </>
+                                                )}
 					</div>
 				</div>
 			)}

--- a/FrontEnd/src/components/dashboard/ApplicationsList.tsx
+++ b/FrontEnd/src/components/dashboard/ApplicationsList.tsx
@@ -11,40 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
 // Mock data for the applications
-const initialApplications = [
-  {
-    id: 101,
-    title: "UX/UI Designer",
-    company: "Creative Designs",
-    appliedDate: "2023-06-15",
-    status: "Interview",
-    response: true
-  },
-  {
-    id: 102,
-    title: "React Native Developer",
-    company: "MobileApps Inc.",
-    appliedDate: "2023-06-10",
-    status: "Applied",
-    response: false
-  },
-  {
-    id: 103,
-    title: "Frontend Developer",
-    company: "WebTech Solutions",
-    appliedDate: "2023-06-05",
-    status: "Rejected",
-    response: true
-  },
-  {
-    id: 104,
-    title: "JavaScript Engineer",
-    company: "CodeMasters",
-    appliedDate: "2023-06-01",
-    status: "Applied",
-    response: false
-  },
-];
+const initialApplications: any[] = [];
 
 const ApplicationsList: React.FC = () => {
   const [applications] = useState(initialApplications);

--- a/FrontEnd/src/components/dashboard/DashboardStats.tsx
+++ b/FrontEnd/src/components/dashboard/DashboardStats.tsx
@@ -10,12 +10,7 @@ import { Progress } from "@/components/ui/progress";
 import { ArrowUpRight } from "lucide-react";
 
 // Mock data for applications - in a real app, this would come from an API or context
-const mockApplications = [
-  { id: 101, title: "UX/UI Designer", company: "Creative Designs", appliedDate: "2023-06-15", status: "Interview", response: true },
-  { id: 102, title: "React Native Developer", company: "MobileApps Inc.", appliedDate: "2023-06-10", status: "Applied", response: false },
-  { id: 103, title: "Frontend Developer", company: "WebTech Solutions", appliedDate: "2023-06-05", status: "Rejected", response: true },
-  { id: 104, title: "JavaScript Engineer", company: "CodeMasters", appliedDate: "2023-06-01", status: "Applied", response: false },
-];
+const mockApplications: any[] = [];
 
 const DashboardStats: React.FC = () => {
   return (
@@ -27,7 +22,7 @@ const DashboardStats: React.FC = () => {
         <CardContent>
           <div className="text-2xl font-bold">{mockApplications.length}</div>
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            <span className="text-green-500 dark:text-green-400">+2</span> from last week
+            <span className="text-green-500 dark:text-green-400">0</span> from last week
           </p>
         </CardContent>
       </Card>
@@ -55,7 +50,7 @@ const DashboardStats: React.FC = () => {
             {mockApplications.filter(app => app.status === "Interview").length}
           </div>
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            <span className="text-green-500 dark:text-green-400">+1</span> scheduled this week
+            <span className="text-green-500 dark:text-green-400">0</span> scheduled this week
           </p>
         </CardContent>
       </Card>
@@ -66,10 +61,10 @@ const DashboardStats: React.FC = () => {
         </CardHeader>
         <CardContent>
           <div className="flex items-center space-x-2">
-            <div className="text-2xl font-bold">78%</div>
+            <div className="text-2xl font-bold">0%</div>
             <ArrowUpRight className="h-4 w-4 text-green-500 dark:text-green-400" />
           </div>
-          <Progress value={78} className="h-2 mt-2" />
+          <Progress value={0} className="h-2 mt-2" />
         </CardContent>
       </Card>
     </div>

--- a/FrontEnd/src/components/dashboard/Internships.tsx
+++ b/FrontEnd/src/components/dashboard/Internships.tsx
@@ -7,41 +7,7 @@ import { Bookmark, Calendar, MapPin, ArrowRight } from "lucide-react";
 
 const Internships = () => {
   // Mock data for internships
-  const internships = [
-    {
-      id: 1,
-      title: "Frontend Development Intern",
-      company: "TechStart Inc.",
-      location: "Remote",
-      duration: "3 months",
-      stipend: "$1,500/month",
-      deadline: "2023-08-15",
-      tags: ["React", "JavaScript", "UI/UX"],
-      isNew: true
-    },
-    {
-      id: 2,
-      title: "UX/UI Design Intern",
-      company: "Creative Solutions",
-      location: "New York, NY",
-      duration: "6 months",
-      stipend: "$2,000/month",
-      deadline: "2023-09-01",
-      tags: ["Figma", "User Research", "Prototyping"],
-      isNew: true
-    },
-    {
-      id: 3,
-      title: "Data Science Intern",
-      company: "DataMinds",
-      location: "San Francisco, CA",
-      duration: "4 months",
-      stipend: "$2,200/month",
-      deadline: "2023-08-20",
-      tags: ["Python", "Machine Learning", "Data Analysis"],
-      isNew: false
-    },
-  ];
+  const internships: any[] = [];
 
   return (
     <Card className="mb-6">

--- a/FrontEnd/src/components/dashboard/JobMatchesList.tsx
+++ b/FrontEnd/src/components/dashboard/JobMatchesList.tsx
@@ -13,38 +13,7 @@ import {
 } from "lucide-react";
 
 // Mock data for the job matches
-const initialJobMatches = [
-  {
-    id: 1,
-    title: "Senior Front-End Developer",
-    company: "TechCorp Inc.",
-    location: "San Francisco, CA",
-    salary: "$120,000 - $150,000",
-    matchScore: 92,
-    posted: "2 days ago",
-    applied: false
-  },
-  {
-    id: 2,
-    title: "Full Stack Engineer",
-    company: "InnovateTech",
-    location: "Remote",
-    salary: "$110,000 - $140,000",
-    matchScore: 88,
-    posted: "1 day ago",
-    applied: false
-  },
-  {
-    id: 3,
-    title: "React Developer",
-    company: "WebSolutions LLC",
-    location: "New York, NY",
-    salary: "$105,000 - $130,000",
-    matchScore: 85,
-    posted: "3 days ago",
-    applied: false
-  },
-];
+const initialJobMatches: any[] = [];
 
 const JobMatchesList: React.FC = () => {
   const [jobMatches, setJobMatches] = useState(initialJobMatches);

--- a/FrontEnd/src/components/dashboard/UserProfile.tsx
+++ b/FrontEnd/src/components/dashboard/UserProfile.tsx
@@ -7,19 +7,17 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 interface UserProfileProps {
   onEditClick: () => void;
+  profile?: any;
 }
 
-const UserProfile: React.FC<UserProfileProps> = ({ onEditClick }) => {
-  // This would come from your user context or API in a real app
-  const user = {
-    name: "John Doe",
-    age: 28,
-    email: "john.doe@example.com",
-    phone: "+1 (555) 123-4567",
-    address: "123 Main Street, San Francisco, CA",
-    role: "Front-End Developer",
-    experience: "3 years",
-    education: "Bachelor's in Computer Science"
+const UserProfile: React.FC<UserProfileProps> = ({ onEditClick, profile }) => {
+  const user = profile || {
+    full_name: "",
+    interested_role: "",
+    experience: 0,
+    email: "",
+    phone: "",
+    address: ""
   };
 
   return (
@@ -34,41 +32,41 @@ const UserProfile: React.FC<UserProfileProps> = ({ onEditClick }) => {
       <CardContent className="grid md:grid-cols-2 gap-6">
         <div className="flex flex-col sm:flex-row gap-4 items-center sm:items-start">
           <Avatar className="h-20 w-20">
-            <AvatarImage src="https://github.com/shadcn.png" alt={user.name} />
+            <AvatarImage src="https://github.com/shadcn.png" alt={user.full_name} />
             <AvatarFallback className="text-lg">
-              {user.name.split(' ').map(n => n[0]).join('')}
+              {user.full_name ? user.full_name.split(' ').map((n: string) => n[0]).join('') : ""}
             </AvatarFallback>
           </Avatar>
-          
+
           <div className="text-center sm:text-left">
-            <h3 className="text-xl font-semibold">{user.name}</h3>
-            <p className="text-gray-600 dark:text-gray-300">{user.role}</p>
-            <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">{user.age} years old</p>
+            <h3 className="text-xl font-semibold">{user.full_name || "-"}</h3>
+            <p className="text-gray-600 dark:text-gray-300">{user.interested_role || "-"}</p>
+            <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">{user.experience ? `${user.experience} yrs exp` : "-"}</p>
           </div>
         </div>
-        
+
         <div className="space-y-3">
           <div className="flex items-start gap-2">
             <Mail className="h-5 w-5 text-gray-500 mt-0.5" />
             <div>
               <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Email</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400">{user.email}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{user.email || "-"}</p>
             </div>
           </div>
-          
+
           <div className="flex items-start gap-2">
             <Phone className="h-5 w-5 text-gray-500 mt-0.5" />
             <div>
               <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Phone</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400">{user.phone}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{user.phone || "-"}</p>
             </div>
           </div>
-          
+
           <div className="flex items-start gap-2">
             <MapPin className="h-5 w-5 text-gray-500 mt-0.5" />
             <div>
               <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Address</p>
-              <p className="text-sm text-gray-600 dark:text-gray-400">{user.address}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{user.address || "-"}</p>
             </div>
           </div>
         </div>

--- a/FrontEnd/src/contexts/AuthContext.tsx
+++ b/FrontEnd/src/contexts/AuthContext.tsx
@@ -26,7 +26,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const register = async (email: string, password: string) => {
     await apiRegister(email, password);
-    toast.success("Account created! Please sign in.");
+    const { data } = await apiLogin(email, password);
+    localStorage.setItem("token", data.access_token);
+    setToken(data.access_token);
+    toast.success("Account created successfully");
   };
 
   const logout = () => {

--- a/FrontEnd/src/pages/Dashboard.tsx
+++ b/FrontEnd/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useQuery } from "@tanstack/react-query";
 import { fetchProfile } from "@/lib/api";
 
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Button } from "@/components/ui/button";
 import { 
   Card, 
@@ -30,10 +30,18 @@ import DashboardStats from '@/components/dashboard/DashboardStats';
 import JobMatchesList from '@/components/dashboard/JobMatchesList';
 import ApplicationsList from '@/components/dashboard/ApplicationsList';
 import AnalyticsDashboard from '@/components/dashboard/AnalyticsDashboard';
+import { useAuth } from "@/contexts/AuthContext";
 
 const Dashboard = () => {
   const [activeTab, setActiveTab] = React.useState("matches");
   const [isEditingProfile, setIsEditingProfile] = React.useState(false);
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  React.useEffect(() => {
+    if (!token) {
+      navigate("/signin");
+    }
+  }, [token, navigate]);
   // Fetch the current user's profile once the dashboard is rendered
   const { data: profile } = useQuery({
     queryKey: ["profile"],
@@ -69,8 +77,8 @@ const Dashboard = () => {
           </div>
           
           <DashboardStats />
-          
-          <UserProfile onEditClick={() => setIsEditingProfile(true)} />
+
+          <UserProfile profile={profile} onEditClick={() => setIsEditingProfile(true)} />
           
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="mb-6">


### PR DESCRIPTION
## Summary
- sign up now logs user in immediately
- show Dashboard & sign-out links only when authenticated
- protect Dashboard route
- remove placeholder profile data and stats
- default dashboard lists to empty

## Testing
- `npm run lint` *(fails: cannot read properties of undefined in eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_687d2c05934483269ccd7c92a9be552f