### PR TITLE
Add password reset flow

### DIFF
--- a/BackEnd/models.py
+++ b/BackEnd/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, Float
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, Float, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime
 
@@ -54,3 +54,15 @@ class JobMatch(Base):
 
     user = relationship("User", back_populates="job_matches")
     job = relationship("Job", back_populates="job_matches")
+
+
+class PasswordReset(Base):
+    __tablename__ = "password_resets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"))
+    otp = Column(String(6))
+    expires_at = Column(DateTime)
+    is_verified = Column(Boolean, default=False)
+
+    user = relationship("User")

--- a/BackEnd/routers/user.py
+++ b/BackEnd/routers/user.py
@@ -1,11 +1,17 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordRequestForm
+from datetime import datetime, timedelta
+import random
 
 from .. import models, schemas
 from ..database import get_db
 from ..auth.hashing import Hash
 from ..auth.tokens import create_access_token
+
+def send_otp_email(to_email: str, otp: str):
+    """Placeholder email sender"""
+    print(f"Sending OTP {otp} to {to_email}")
 
 router = APIRouter(
     prefix="/user",
@@ -35,3 +41,63 @@ def login_user(request: OAuth2PasswordRequestForm = Depends(), db: Session = Dep
 
     access_token = create_access_token(data={"user_id": user.id})
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/request-password-reset")
+def request_password_reset(request: schemas.PasswordResetRequest, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.email == request.email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    otp = f"{random.randint(100000, 999999)}"
+    expires = datetime.utcnow() + timedelta(minutes=10)
+    reset = models.PasswordReset(user_id=user.id, otp=otp, expires_at=expires)
+    db.add(reset)
+    db.commit()
+
+    send_otp_email(user.email, otp)
+    return {"message": "OTP sent"}
+
+
+@router.post("/verify-otp")
+def verify_otp(request: schemas.OTPVerify, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.email == request.email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    reset = (
+        db.query(models.PasswordReset)
+        .filter(models.PasswordReset.user_id == user.id, models.PasswordReset.otp == request.otp, models.PasswordReset.expires_at > datetime.utcnow())
+        .order_by(models.PasswordReset.id.desc())
+        .first()
+    )
+    if not reset:
+        raise HTTPException(status_code=400, detail="Invalid OTP")
+    reset.is_verified = True
+    db.commit()
+    return {"message": "OTP verified"}
+
+
+@router.post("/reset-password")
+def reset_password(request: schemas.PasswordUpdate, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.email == request.email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    reset = (
+        db.query(models.PasswordReset)
+        .filter(
+            models.PasswordReset.user_id == user.id,
+            models.PasswordReset.otp == request.otp,
+            models.PasswordReset.expires_at > datetime.utcnow(),
+            models.PasswordReset.is_verified == True,
+        )
+        .order_by(models.PasswordReset.id.desc())
+        .first()
+    )
+    if not reset:
+        raise HTTPException(status_code=400, detail="Invalid OTP")
+
+    user.hashed_password = Hash.bcrypt(request.password)
+    db.commit()
+    return {"message": "Password updated"}

--- a/BackEnd/schemas.py
+++ b/BackEnd/schemas.py
@@ -77,3 +77,20 @@ class JobMatchOut(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+# ---------------- Password Reset Schemas ----------------
+
+class PasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class OTPVerify(BaseModel):
+    email: EmailStr
+    otp: str
+
+
+class PasswordUpdate(BaseModel):
+    email: EmailStr
+    otp: str
+    password: str

--- a/FrontEnd/src/App.tsx
+++ b/FrontEnd/src/App.tsx
@@ -8,6 +8,7 @@ import React from 'react'; // Add explicit React import
 import Index from "./pages/Index";
 import SignIn from "./pages/SignIn";
 import SignUp from "./pages/SignUp";
+import ForgotPassword from "./pages/ForgotPassword";
 import About from "./pages/About";
 import Dashboard from "./pages/Dashboard";
 import ResumeUpload from "./pages/ResumeUpload";
@@ -55,6 +56,7 @@ const App = () => {
                 <Route path="/" element={<Index />} />
                 <Route path="/signin" element={<SignIn />} />
                 <Route path="/signup" element={<SignUp />} />
+                <Route path="/forgot-password" element={<ForgotPassword />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/resume-upload" element={<ResumeUpload />} />

--- a/FrontEnd/src/components/passwordReset/EmailForm.tsx
+++ b/FrontEnd/src/components/passwordReset/EmailForm.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+  onSubmit: (email: string) => void;
+}
+
+const EmailForm: React.FC<Props> = ({ onSubmit }) => {
+  const handle = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const email = fd.get('email') as string;
+    if (email) onSubmit(email);
+  };
+  return (
+    <form onSubmit={handle} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="fp-email">Registered Email</Label>
+        <Input id="fp-email" name="email" type="email" required />
+      </div>
+      <Button type="submit" className="w-full">Send OTP</Button>
+    </form>
+  );
+};
+
+export default EmailForm;

--- a/FrontEnd/src/components/passwordReset/NewPasswordForm.tsx
+++ b/FrontEnd/src/components/passwordReset/NewPasswordForm.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+  onSubmit: (password: string, confirm: string) => void;
+}
+
+const NewPasswordForm: React.FC<Props> = ({ onSubmit }) => {
+  const handle = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const password = fd.get('password') as string;
+    const confirm = fd.get('confirm') as string;
+    onSubmit(password, confirm);
+  };
+  return (
+    <form onSubmit={handle} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="password">New Password</Label>
+        <Input id="password" name="password" type="password" required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="confirm">Confirm Password</Label>
+        <Input id="confirm" name="confirm" type="password" required />
+      </div>
+      <Button type="submit" className="w-full">Reset Password</Button>
+    </form>
+  );
+};
+
+export default NewPasswordForm;

--- a/FrontEnd/src/components/passwordReset/OtpForm.tsx
+++ b/FrontEnd/src/components/passwordReset/OtpForm.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+  onSubmit: (otp: string) => void;
+}
+
+const OtpForm: React.FC<Props> = ({ onSubmit }) => {
+  const handle = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const otp = fd.get('otp') as string;
+    if (otp) onSubmit(otp);
+  };
+
+  return (
+    <form onSubmit={handle} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="otp">Enter OTP sent to your email</Label>
+        <Input id="otp" name="otp" required />
+      </div>
+      <Button type="submit" className="w-full">Verify OTP</Button>
+    </form>
+  );
+};
+
+export default OtpForm;

--- a/FrontEnd/src/lib/api.ts
+++ b/FrontEnd/src/lib/api.ts
@@ -28,3 +28,12 @@ export const uploadProfile = (form: FormData) =>
   api.post("/profile/", form);
 
 export const fetchProfile = () => api.get("/profile/");
+
+export const requestPasswordReset = (email: string) =>
+  api.post("/user/request-password-reset", { email });
+
+export const verifyOtp = (email: string, otp: string) =>
+  api.post("/user/verify-otp", { email, otp });
+
+export const resetPassword = (email: string, otp: string, password: string) =>
+  api.post("/user/reset-password", { email, otp, password });

--- a/FrontEnd/src/pages/ForgotPassword.tsx
+++ b/FrontEnd/src/pages/ForgotPassword.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { toast } from 'sonner';
+import { useNavigate } from 'react-router-dom';
+import Navbar from '@/components/Navbar';
+import EmailForm from '@/components/passwordReset/EmailForm';
+import OtpForm from '@/components/passwordReset/OtpForm';
+import NewPasswordForm from '@/components/passwordReset/NewPasswordForm';
+import { requestPasswordReset, verifyOtp, resetPassword } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+const ForgotPassword = () => {
+  const [step, setStep] = useState<'email' | 'otp' | 'reset'>('email');
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const { login } = useAuth();
+  const navigate = useNavigate();
+
+  const handleEmail = async (em: string) => {
+    try {
+      await requestPasswordReset(em);
+      setEmail(em);
+      toast.success('OTP sent to your email');
+      setStep('otp');
+    } catch (err) {
+      toast.error('Unable to send OTP');
+    }
+  };
+
+  const handleOtp = async (o: string) => {
+    try {
+      await verifyOtp(email, o);
+      setOtp(o);
+      toast.success('OTP verified');
+      setStep('reset');
+    } catch {
+      toast.error('Invalid OTP');
+    }
+  };
+
+  const handleReset = async (password: string, confirm: string) => {
+    if (password !== confirm) {
+      toast.error('Passwords do not match');
+      return;
+    }
+    const valid = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
+    if (!valid.test(password)) {
+      toast.error('Password must be 8+ chars with letters, numbers and symbol');
+      return;
+    }
+    try {
+      await resetPassword(email, otp, password);
+      toast.success('Password updated');
+      await login(email, password);
+      navigate('/dashboard');
+    } catch {
+      toast.error('Failed to reset password');
+    }
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 'email':
+        return <EmailForm onSubmit={handleEmail} />;
+      case 'otp':
+        return <OtpForm onSubmit={handleOtp} />;
+      case 'reset':
+        return <NewPasswordForm onSubmit={handleReset} />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 hero-gradient">
+        <div className="w-full max-w-md space-y-8 animate-fade-in glass-card p-8 rounded-xl shadow-xl">
+          {renderStep()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;


### PR DESCRIPTION
## Summary
- implement database model and API routes for password reset
- add API helpers on the frontend
- create password reset components
- add Forgot Password page and route

## Testing
- `npm run build`
- `pip install -r BackEnd/requirements.txt`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_687e04f57b608326bd0d2ba0ea5563a1