### PR TITLE
Implement email confirmation via OTP

### DIFF
--- a/BackEnd/models.py
+++ b/BackEnd/models.py
@@ -66,3 +66,13 @@ class PasswordReset(Base):
     is_verified = Column(Boolean, default=False)
 
     user = relationship("User")
+
+
+class RegistrationOTP(Base):
+    __tablename__ = "registration_otps"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True)
+    hashed_password = Column(String(255))
+    otp = Column(String(6))
+    expires_at = Column(DateTime)

--- a/BackEnd/schemas.py
+++ b/BackEnd/schemas.py
@@ -10,6 +10,16 @@ class UserCreate(BaseModel):
     password: str
 
 
+class RegistrationRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RegistrationVerify(BaseModel):
+    email: EmailStr
+    otp: str
+
+
 class UserLogin(BaseModel):
     email: EmailStr
     password: str

--- a/FrontEnd/src/components/signup/OtpForm.tsx
+++ b/FrontEnd/src/components/signup/OtpForm.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+  onSubmit: (otp: string) => void;
+  onExpire: () => void;
+}
+
+const SignupOtpForm: React.FC<Props> = ({ onSubmit, onExpire }) => {
+  const [timeLeft, setTimeLeft] = useState(60);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeLeft((t) => {
+        if (t <= 1) {
+          clearInterval(interval);
+          onExpire();
+          return 0;
+        }
+        return t - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [onExpire]);
+
+  const handle = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const otp = fd.get('otp') as string;
+    if (otp) onSubmit(otp);
+  };
+
+  return (
+    <form onSubmit={handle} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="otp">Enter OTP sent to your email</Label>
+        <Input id="otp" name="otp" required />
+        <p className="text-sm text-gray-500">Time remaining: {timeLeft}s</p>
+      </div>
+      <Button type="submit" className="w-full">Verify OTP</Button>
+    </form>
+  );
+};
+
+export default SignupOtpForm;

--- a/FrontEnd/src/lib/api.ts
+++ b/FrontEnd/src/lib/api.ts
@@ -17,6 +17,12 @@ export default api;
 export const register = (email: string, password: string) =>
   api.post("/user/register", { email, password });
 
+export const requestRegistration = (email: string, password: string) =>
+  api.post("/user/request-registration", { email, password });
+
+export const confirmRegistration = (email: string, otp: string) =>
+  api.post("/user/confirm-registration", { email, otp });
+
 export const login = (email: string, password: string) =>
   api.post(
     "/user/login",


### PR DESCRIPTION
## Summary
- add `RegistrationOTP` table and schemas for sign-up OTP flow
- implement backend endpoints to request and confirm registration using OTP
- create frontend API wrappers for new endpoints
- add OTP entry form with one minute timer
- update sign up page to handle OTP verification workflow

## Testing
- `python3 -m py_compile BackEnd/**/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e3ba3e1d4832680dd86711f7667fc