### PR TITLE
Add personal info signup step and resume upload

### DIFF
--- a/BackEnd/main.py
+++ b/BackEnd/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import user, profile
+from .routers import user, profile, personal_info
 from .database import Base, engine
 
 # Create all tables
@@ -29,3 +29,4 @@ app.add_middleware(
 # Include routers
 app.include_router(user.router)
 app.include_router(profile.router)
+app.include_router(personal_info.router)

--- a/BackEnd/models.py
+++ b/BackEnd/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, Float, Boolean
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, Float, Boolean, Date
 from sqlalchemy.orm import relationship
 from datetime import datetime
 
@@ -80,3 +80,23 @@ class RegistrationOTP(Base):
     hashed_password = Column(String(255))
     otp = Column(String(6))
     expires_at = Column(DateTime)
+
+
+class PersonalInformation(Base):
+    __tablename__ = "personal_information"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
+    dob = Column(Date, nullable=True)
+    country = Column(String(100))
+    state = Column(String(100))
+    city = Column(String(100))
+    street = Column(String(255))
+    house_number = Column(String(50))
+    pin_code = Column(String(20))
+    phone_number = Column(String(50))
+    current_job_role = Column(String(100))
+    company = Column(String(100))
+    resume_path = Column(String(255))
+
+    user = relationship("User", backref="personal_info", uselist=False)

--- a/BackEnd/routers/personal_info.py
+++ b/BackEnd/routers/personal_info.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from sqlalchemy.orm import Session
+from uuid import uuid4
+import os
+
+from .. import models, schemas
+from ..database import get_db
+from ..auth.dependencies import get_current_user
+
+UPLOAD_DIR = "uploads"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+router = APIRouter(prefix="/personal-info", tags=["PersonalInfo"])
+
+@router.post("/", response_model=schemas.PersonalInfoOut)
+def create_or_update_info(
+    info: schemas.PersonalInfoCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    record = db.query(models.PersonalInformation).filter(models.PersonalInformation.user_id == current_user.id).first()
+    if record:
+        for field, value in info.dict(exclude_unset=True).items():
+            setattr(record, field, value)
+    else:
+        record = models.PersonalInformation(user_id=current_user.id, **info.dict())
+        db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+@router.post("/resume", response_model=schemas.PersonalInfoOut)
+def upload_resume(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    ext = os.path.splitext(file.filename)[1]
+    filename = f"{current_user.id}_{uuid4().hex}{ext}"
+    path = os.path.join(UPLOAD_DIR, filename)
+    with open(path, "wb") as f:
+        f.write(file.file.read())
+
+    record = db.query(models.PersonalInformation).filter(models.PersonalInformation.user_id == current_user.id).first()
+    if not record:
+        record = models.PersonalInformation(user_id=current_user.id, resume_path=path)
+        db.add(record)
+    else:
+        record.resume_path = path
+    db.commit()
+    db.refresh(record)
+    return record

--- a/BackEnd/schemas.py
+++ b/BackEnd/schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, date
 
 
 # ---------------- User Schemas ----------------
@@ -108,3 +108,30 @@ class PasswordUpdate(BaseModel):
     email: EmailStr
     otp: str
     password: str
+
+
+# ---------------- Personal Info Schemas ----------------
+
+class PersonalInfoBase(BaseModel):
+    dob: Optional[date] = None
+    country: Optional[str] = None
+    state: Optional[str] = None
+    city: Optional[str] = None
+    street: Optional[str] = None
+    house_number: Optional[str] = None
+    pin_code: Optional[str] = None
+    phone_number: Optional[str] = None
+    current_job_role: Optional[str] = None
+    company: Optional[str] = None
+
+
+class PersonalInfoCreate(PersonalInfoBase):
+    pass
+
+
+class PersonalInfoOut(PersonalInfoBase):
+    id: int
+    resume_path: Optional[str] = None
+
+    class Config:
+        from_attributes = True

--- a/FrontEnd/src/App.tsx
+++ b/FrontEnd/src/App.tsx
@@ -12,6 +12,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import About from "./pages/About";
 import Dashboard from "./pages/Dashboard";
 import ResumeUpload from "./pages/ResumeUpload";
+import PersonalInfo from "./pages/PersonalInfo";
 import NotFound from "./pages/NotFound";
 import FAQ from "./pages/FAQ";
 import Pricing from "./pages/Pricing";
@@ -59,6 +60,7 @@ const App = () => {
                 <Route path="/forgot-password" element={<ForgotPassword />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/personal-info" element={<PersonalInfo />} />
                 <Route path="/resume-upload" element={<ResumeUpload />} />
                 <Route path="/faq" element={<FAQ />} />
                 <Route path="/pricing" element={<Pricing />} />

--- a/FrontEnd/src/lib/api.ts
+++ b/FrontEnd/src/lib/api.ts
@@ -33,6 +33,12 @@ export const login = (email: string, password: string) =>
 export const uploadProfile = (form: FormData) =>
   api.post("/profile/", form);
 
+export const savePersonalInfo = (data: Record<string, unknown>) =>
+  api.post("/personal-info/", data);
+
+export const uploadResume = (form: FormData) =>
+  api.post("/personal-info/resume", form);
+
 export const fetchProfile = () => api.get("/profile/");
 
 export const requestPasswordReset = (email: string) =>

--- a/FrontEnd/src/pages/PersonalInfo.tsx
+++ b/FrontEnd/src/pages/PersonalInfo.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from "sonner";
+import Navbar from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { savePersonalInfo } from '@/lib/api';
+
+const PersonalInfo = () => {
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const data: Record<string, unknown> = {
+      dob: fd.get('dob'),
+      country: fd.get('country'),
+      state: fd.get('state'),
+      city: fd.get('city'),
+      street: fd.get('street'),
+      house_number: fd.get('house_number'),
+      pin_code: fd.get('pin_code'),
+      phone_number: fd.get('phone_number'),
+      current_job_role: fd.get('current_job_role'),
+      company: fd.get('company'),
+    };
+    try {
+      await savePersonalInfo(data);
+      toast.success('Information saved');
+      navigate('/resume-upload');
+    } catch {
+      toast.error('Unable to save information');
+    }
+  };
+
+  const handleSkip = () => {
+    if (window.confirm('Skip adding personal info? You can fill it later.')) {
+      navigate('/resume-upload');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-1 hero-gradient flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+        <Card className="w-full max-w-xl p-8 space-y-6 glass-card animate-fade-in">
+          <h2 className="text-2xl font-bold text-center">Personal Information</h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="dob">Date of Birth</Label>
+              <Input id="dob" name="dob" type="date" />
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="country">Country</Label>
+                <Input id="country" name="country" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="state">State</Label>
+                <Input id="state" name="state" />
+              </div>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="city">City</Label>
+                <Input id="city" name="city" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="street">Street</Label>
+                <Input id="street" name="street" />
+              </div>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="house_number">House No.</Label>
+                <Input id="house_number" name="house_number" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="pin_code">PIN Code</Label>
+                <Input id="pin_code" name="pin_code" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone_number">Phone Number</Label>
+              <Input id="phone_number" name="phone_number" />
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="current_job_role">Current Job Role</Label>
+                <Input id="current_job_role" name="current_job_role" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="company">Company</Label>
+                <Input id="company" name="company" />
+              </div>
+            </div>
+            <div className="flex justify-end gap-4 pt-4">
+              <Button type="button" variant="outline" onClick={handleSkip}>Skip</Button>
+              <Button type="submit">Continue</Button>
+            </div>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default PersonalInfo;

--- a/FrontEnd/src/pages/ResumeUpload.tsx
+++ b/FrontEnd/src/pages/ResumeUpload.tsx
@@ -7,7 +7,7 @@ import { Card } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Upload, FileText, Check, AlertCircle } from "lucide-react";
 import Navbar from '@/components/Navbar';
-import { uploadProfile } from "@/lib/api";
+import { uploadResume } from "@/lib/api";
 
 const ResumeUpload = () => {
   const navigate = useNavigate();
@@ -16,6 +16,12 @@ const ResumeUpload = () => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [uploadComplete, setUploadComplete] = useState(false);
+
+  const handleSkip = () => {
+    if (window.confirm('Skip resume upload? You can upload later.')) {
+      navigate('/dashboard');
+    }
+  };
 
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -64,14 +70,11 @@ const ResumeUpload = () => {
   const handleUpload = async () => {
     if (!file) return;
 
-    const form =  new FormData();
-    form.append("full_name", "John Doe");
-    form.append("interested_role", "Backend Engineer");
-    form.append("experience", "3");
-    form.append("resume", file);
+    const form = new FormData();
+    form.append("file", file);
 
     setIsUploading(true);
-    await uploadProfile(form);
+    await uploadResume(form);
     setUploadProgress(0);
 
     setIsUploading(false);
@@ -131,6 +134,7 @@ const ResumeUpload = () => {
             <p className="mt-3 text-lg text-gray-600 dark:text-gray-300">
               Let our AI analyze your resume and find the perfect job matches for you
             </p>
+            <Button variant="ghost" onClick={handleSkip} className="mt-4">Skip for now</Button>
           </div>
 
           <Card className="p-6 shadow-lg glass-card">

--- a/FrontEnd/src/pages/SignUp.tsx
+++ b/FrontEnd/src/pages/SignUp.tsx
@@ -42,7 +42,7 @@ const SignUp = () => {
       await confirmRegistration(email, otp);
       toast.success('Account verified');
       await login(email, password);
-      navigate('/dashboard');
+      navigate('/personal-info');
     } catch {
       toast.error('OTP incorrect');
     }


### PR DESCRIPTION
## Summary
- create new `personal_information` table
- expose `/personal-info` API endpoints for storing personal info and resume
- add UI for personal info step after sign up
- allow uploading resume or skipping
- wire new routes in app and sign‑up flow

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f7cedb59c8326bf2ac4703bc7d8a2