### PR TITLE
Fix signup bcrypt warning and profile not found log

### DIFF
--- a/BackEnd/requirements.txt
+++ b/BackEnd/requirements.txt
@@ -4,6 +4,7 @@ sqlalchemy
 pymysql
 pydantic
 passlib[bcrypt]
+bcrypt<4
 python-jose
 requests
 beautifulsoup4

--- a/BackEnd/routers/user.py
+++ b/BackEnd/routers/user.py
@@ -30,6 +30,11 @@ def register_user(request: schemas.UserCreate, db: Session = Depends(get_db)):
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
+
+    # Create an empty profile record so initial profile fetches succeed
+    profile = models.UserProfile(user_id=new_user.id)
+    db.add(profile)
+    db.commit()
     return new_user
 
 
@@ -76,6 +81,11 @@ def confirm_registration(request: schemas.RegistrationVerify, db: Session = Depe
     db.delete(record)
     db.commit()
     db.refresh(new_user)
+
+    # Ensure a profile exists for newly registered users
+    profile = models.UserProfile(user_id=new_user.id)
+    db.add(profile)
+    db.commit()
     return new_user
 
 


### PR DESCRIPTION
## Summary
- pin `bcrypt` to avoid passlib version warning
- create an empty `UserProfile` when registering a new user so `/profile/` does not 404 immediately

## Testing
- `pip install -q -r BackEnd/requirements.txt`
- `python -m py_compile BackEnd/routers/user.py`


------
https://chatgpt.com/codex/tasks/task_e_6880ff726d7c8326834996157dd3b5a3